### PR TITLE
Update certificate name change instructions

### DIFF
--- a/CertificateGenerator/certificate-generator.html
+++ b/CertificateGenerator/certificate-generator.html
@@ -194,7 +194,7 @@
                     <li><strong>Step 2:</strong> Verify your registered name and click "Generate Certificate"</li>
                     <li>Make sure your Student ID is correct - only <strong>registered CyberCon24</strong>  participants can generate certificates</li>
                     <li>The name on your certificate will match your registration details exactly</li>
-                    <li><strong><a href="https://facebook.com/csc.uu.bd">Contact support</a></strong> if you need to update your <strong>registered name</strong></li>
+                    <li><strong>Name can't be changeable once generated</strong></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Replaces the support contact link with a notice that names cannot be changed once the certificate is generated.