### PR TITLE
Fix site-credit div closure and script paths in HTML files

### DIFF
--- a/CTFMonthly.html
+++ b/CTFMonthly.html
@@ -231,7 +231,6 @@
       </div>
       <div class="site-credit">
 ©2025 | Developed by Cyber Security Club, Uttara University 
-      </div>
     </div>
       <!-- GitHub Contributors Section -->
 <div class="github-contributors-section">

--- a/CTFWeekly.html
+++ b/CTFWeekly.html
@@ -232,7 +232,6 @@
       <div class="site-credit">
 ©2025 | Developed by Cyber Security Club, Uttara University 
       </div>
-    </div>
       <!-- GitHub Contributors Section -->
 <div class="github-contributors-section">
   <div class="github-contributors-title">
@@ -386,5 +385,6 @@
     
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="assets/js/index.js"></script>
+    <script src="assets/js/git-cont.js"></script>
 </body>
 </html>

--- a/CTFWriteups.html
+++ b/CTFWriteups.html
@@ -332,7 +332,6 @@
       <div class="site-credit">
 ©2025 | Developed by Cyber Security Club, Uttara University 
       </div>
-    </div>
       <!-- GitHub Contributors Section -->
 <div class="github-contributors-section">
   <div class="github-contributors-title">

--- a/CertificateGenerator/certificate-generator.html
+++ b/CertificateGenerator/certificate-generator.html
@@ -234,7 +234,6 @@
             <div class="site-credit">
                 ©2025 | Developed by Cyber Security Club, Uttara University 
             </div>
-        </div>
     <!-- GitHub Contributors Section -->
 <div class="github-contributors-section">
   <div class="github-contributors-title">
@@ -267,7 +266,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="../assets/js/index.js"></script>
     <script src="certificate-generator.js"></script>
-    <script src="assets/js/git-cont.js"></script>
+    <script src="../assets/js/git-cont.js"></script>
+    
     
     <script>
         // Show welcome notification when page loads


### PR DESCRIPTION
Removes redundant closing div tags after the site-credit section in multiple HTML files to correct markup structure. Updates the path for git-cont.js in certificate-generator.html and adds the script to CTFWeekly.html for proper contributor section functionality.