### PR TITLE
Update news card link and title for CTF Night 0x2

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,13 +260,13 @@
           <h2 class="news-main-title">Latest News & Highlights</h2>
         </div>    
         <div class="news-container" id="newsContainer">
-            <a href="NewsPortal/weekly-ctf-0x1-results.html" class="news-card-link">
+            <a href="http://ctf-cybersecurity-club-uttara.duckdns.org/scoreboard" class="news-card-link">
             <article class="news-card">
               <div class="news-card-image">
                 <img src="/assets/images/CTF/CTF-NIGHT0x2.jpg" alt="Weekly CTF 0x1 Results">
               </div>
               <div class="news-card-content">
-                <h3 class="news-card-title">Weekly CTF 0x2 - Is live</h3>
+                <h3 class="news-card-title">CTF Night 0x2 - Is live</h3>
                 <p class="news-card-date">1 NOVEMBER, 2025</p>
               </div>
             </article>


### PR DESCRIPTION
Changed the news card link to point to the scoreboard and updated the title from 'Weekly CTF 0x2 - Is live' to 'CTF Night 0x2 - Is live' for clarity.