### PR TITLE
Update news card link URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
           <h2 class="news-main-title">Latest News & Highlights</h2>
         </div>    
         <div class="news-container" id="newsContainer">
-            <a href="http://ctf-cybersecurity-club-uttara.duckdns.org/scoreboard" class="news-card-link">
+            <a href="http://ctf-cybersecurity-club-uttara.duckdns.org/" class="news-card-link">
             <article class="news-card">
               <div class="news-card-image">
                 <img src="/assets/images/CTF/CTF-NIGHT0x2.jpg" alt="Weekly CTF 0x1 Results">


### PR DESCRIPTION
Changed the news card link from the scoreboard page to the main site URL for improved navigation.