### PR TITLE
Fix image filename case in gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -296,7 +296,7 @@
             <a href="https://www.facebook.com/share/p/1GB1o3487V/" class="gallery-photo grid-item-animated" target="_blank"
               rel="noreferrer">
               <div>
-                <img class="gallery-photo_image" src="assets/images/Gallery/2025/mist25.jpg" alt="MIST CTF 2025">
+                <img class="gallery-photo_image" src="assets/images/Gallery/2025/MIST25.jpg" alt="MIST CTF 2025">
               </div>
               <div class="gallery-photo_caption-container">
                 <div class="gallery-photo_caption-title">MIST CTF 2025</div>


### PR DESCRIPTION
Corrected the filename case for the MIST CTF 2025 image in gallery.html to ensure proper loading on case-sensitive file systems.